### PR TITLE
Updated to Selenium 4.11.2 to fix ChromeDriver 114 & Chrome 116 depen…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,6 @@ RUN apt-get -y update
 
 RUN apt-get install -y google-chrome-stable
 
-# Installing Unzip
-RUN apt-get install -yqq unzip
-
-
-# Download the Chrome Driver
-
-RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip
-
-
-# Unzip the Chrome Driver into /usr/local/bin directory
-RUN unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
-
 
 # Set display port as an environment variable
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -81,7 +82,10 @@ def TrackerLogin(tracker, user_keys, tracker_keys):
             user = user_keys["user_login"]
             passwd = user_keys["pass_login"]
             
-            driver = webdriver.Chrome(options=set_chrome_options())
+            # Use the new Selenium Manager to auto download ChromeDriver if it's missing
+            service = Service()
+
+            driver = webdriver.Chrome(service=service, options=set_chrome_options())
             driver.get(url)
             
             wait = WebDriverWait(driver, 10)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-selenium==3.141.0
+selenium==4.11.2
 requests==2.28.2
 numpy==1.24.2


### PR DESCRIPTION
…dency problem

Selenium 4.11.2 fixes the ChromeDriver 114 & Chrome 116 dependency issue that was introduced. Updating to the latest Selenium & using the new Selenium Manager to download ChromeDriver if it's missing. This also removes the need to manually download & install ChromeDriver via the Dockerfile.

The error observed was as follows:

ERROR:root:2023-08-30 10:18:09.467420 : Failed to login to Site-XXX due to Error: Message: session not created: This version of ChromeDriver only supports Chrome version 114 Current browser version is 116.0.5845.110 with binary path /usr/bin/google-chrome

Main fix available here:
- https://stackoverflow.com/questions/76727774/selenium-webdriver-chrome-115-stopped-working/76731553#76731553

More info avaialble here:
- https://stackoverflow.com/questions/76970623/chromedriver-only-supports-chrome-version-114-current-browser-version-is-116-0-5
- https://stackoverflow.com/questions/76913935/selenium-common-exceptions-sessionnotcreatedexception-this-version-of-chromedri