### PR TITLE
Fixes for Issue #16 + extra config file handling cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import numpy as np
 import init_configs
 from custom_logger import logging
 import os
+from init_configs import read_valid_json_file
 
 def set_chrome_options() -> None:
 
@@ -136,16 +137,15 @@ def TrackerLogin(tracker, user_keys, tracker_keys):
             return False            
 
 
-
-
 if __name__ == "__main__":
 
-    with open(os.path.join(os.getcwd(), "config/tracker_config.json"), 'r') as f:
-        tracker_config = json.load(f)
+    tracker_config = read_valid_json_file(os.path.join(os.getcwd(), "config/tracker_config.json"), 'r')
+    user_config = read_valid_json_file(os.path.join(os.getcwd(), "config/user_config.json"), 'r')
 
-    with open(os.path.join(os.getcwd(), "config/user_config.json"), 'r') as f:
-        user_config = json.load(f)
-        
+    # Check if there's tracker accounts in the JSON. If not it's still the default file.
+    if len(user_config.keys()) <= 4:
+        logging.error("You don't have any trackers in the 'user_config.json' file. Please look at 'user_config_sample.json' for examples")
+       
     hours_sleep = user_config["Hours_Rerun"]
     connection_url = user_config["CheckConnectionURL"]
     fail_connection = 0
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         is_connected = CheckConnection(connection_url)
         loop_sleep = np.round(np.random.uniform(0.5, 1.0) * hours_sleep)
         curr_time = str(datetime.datetime.now())
-        
+
         if is_connected == True:
             logging.debug(curr_time + " : " + "Successful connection to internet via " + connection_url)
             for t in user_config.keys():

--- a/custom_logger.py
+++ b/custom_logger.py
@@ -2,6 +2,7 @@ import os
 import logging
 import json
 import sys
+from init_configs import read_valid_json_file
 
 dir_ = os.path.join(os.getcwd(), "config/logs/")
 if os.path.isdir(dir_) == False:
@@ -9,9 +10,8 @@ if os.path.isdir(dir_) == False:
 
 log_filename = os.path.join(dir_, "trackerautologin.log")
 
-with open(os.path.join(os.getcwd(), "config/user_config.json"), 'r') as f:
-    user_config = json.load(f)
-    
+user_config = read_valid_json_file(os.path.join(os.getcwd(), "config/user_config.json"), 'r')
+
 assert(user_config["LogLevel"].lower() in ["debug", "error", "warning"]),"LogLevel must be ['debug', 'warning', 'error']"
 
 assert(user_config["LogType"].lower() in ["file", "stderr"]),"'LogType' must be ['file', 'stderr']"

--- a/init_configs.py
+++ b/init_configs.py
@@ -2,63 +2,58 @@ import os
 import urllib.request
 import json
 import numpy as np
+import shutil
+
+# Basic JSON validation of the files. 
+# TODO: Actually validate this against a schema.
+def read_valid_json_file(filename, permission):
+    try:
+        with open(filename, permission) as f:
+            try:
+                json_file = json.load(f)
+            except ValueError as e:
+                # Invalid JSON found in the file. Throw an error
+                print("Invalid JSON structure found in " + filename + ". Exiting the app.")
+                exit()
+
+            return json_file
+    except IOError:
+        print("Your " + filename + " file is missing. Exiting the app.")
+        exit()
 
 tracker_file = os.path.join(os.getcwd(), "config/tracker_config.json")
 tracker_file_temp = os.path.join(os.getcwd(), "config/temp_tracker_config.json")
 
-user_file = os.path.join(os.getcwd(), "config/user_config.json")
-user_file_temp = os.path.join(os.getcwd(), "config/temp_user_config.json")
-
 tconfig_url = "https://raw.githubusercontent.com/mastiffmushroom/TrackerAutoLogin/main/config/tracker_config.json"
-uconfig_url = "https://raw.githubusercontent.com/mastiffmushroom/TrackerAutoLogin/main/config/user_config_sample.json"
-    
+
 if os.path.isfile(tracker_file) == False:
     urllib.request.urlretrieve(tconfig_url, tracker_file)
 else:
     urllib.request.urlretrieve(tconfig_url, tracker_file_temp)
     
-    with open(tracker_file, 'r') as f:
-        u_dict = json.load(f)
-        
-    with open(tracker_file_temp, 'r') as f:
-        t_dict = json.load(f)
+    u_dict = read_valid_json_file(tracker_file, 'r')
+    t_dict = read_valid_json_file(tracker_file_temp, 'r')
         
     for key in t_dict.keys():
-        u_dict[key] = t_dict[key]
-        
-    with open(tracker_file, 'w') as f:
-        json.dump(u_dict, f, indent=4, sort_keys=True)
-
-if os.path.isfile(user_file) == False:
-    urllib.request.urlretrieve(uconfig_url, user_file)
-else:
-    urllib.request.urlretrieve(uconfig_url, user_file_temp)
+       u_dict[key] = t_dict[key]
     
-    with open(user_file, 'r') as f:
-        u_dict = json.load(f)
-        
-    with open(user_file_temp, 'r') as f:
-        t_dict = json.load(f)
-        
-    for key in t_dict.keys():
-        if key not in u_dict.keys():
-            u_dict[key] = t_dict[key]
-            
-    with open(tracker_file, 'r') as f:
-        trackers = list(json.load(f).keys())
-        
-    ut_dict = {}    
-            
-    for key in t_dict.keys():
-        if key not in trackers:
-            if key in u_dict.keys():
-                ut_dict[key] = u_dict[key]
-            else:
-                ut_dict[key] = t_dict[key]
-            
-    for track in trackers:
-        if track in u_dict.keys():
-            ut_dict[track] = u_dict[track]
-            
-    with open(user_file, 'w') as f:
-        json.dump(ut_dict, f, indent=4)
+    # tracker_file has already been validated, shouldn't be a need to do it again
+    with open(tracker_file, 'w') as f:
+       json.dump(u_dict, f, indent=4, sort_keys=True)
+
+# Remove the temp tracker file if it still exists
+if os.path.isfile(tracker_file_temp) == True:
+    os.remove(tracker_file_temp)
+
+# Check if the user_config.json file exists, if not create the initial version with no trackers
+user_file = os.path.join(os.getcwd(), "config/user_config.json")
+if os.path.isfile(user_file) == False:
+    user_file_default = os.path.join(os.getcwd(), "user_config_default.json")
+    shutil.copyfile(user_file_default, user_file)
+
+# Check if the user_config_sample.json file exists, if not download it
+user_file_sample = os.path.join(os.getcwd(), "config/user_config_sample.json")
+uconfig_url = "https://raw.githubusercontent.com/mastiffmushroom/TrackerAutoLogin/main/config/user_config_sample.json"
+
+if os.path.isfile(user_file_sample) == False:
+    urllib.request.urlretrieve(uconfig_url, user_file_sample)

--- a/user_config_default.json
+++ b/user_config_default.json
@@ -1,6 +1,0 @@
-{
-    "LogType": "stderr",
-    "LogLevel": "debug",
-    "Hours_Rerun": 24,
-    "CheckConnectionURL": "https://www.google.com/"
-}

--- a/user_config_default.json
+++ b/user_config_default.json
@@ -1,0 +1,6 @@
+{
+    "LogType": "stderr",
+    "LogLevel": "debug",
+    "Hours_Rerun": 24,
+    "CheckConnectionURL": "https://www.google.com/"
+}


### PR DESCRIPTION
This fixes the issue for #16 where "Running container causes the user_config.json to re-update". This logic has been modified slightly to instead use a "default" user_config.json file which contains no trackers initially. This stops TAL from hitting the same trackers with dummy accounts when it runs the first time. 

- Moved user_config.json to a local file.
- Added checks for whether any trackers are in the user_config.json file.
- Added removal of the old "temp" config files which were left behind too. 
- Added extra error handling for missing and invalid config files 
- Added basic JSON validation to catch config errors. 
- Todo: enhance the basic JSON validation with proper schema validation"